### PR TITLE
Add -j<integer> to skip <integer> frames prior to capture

### DIFF
--- a/README
+++ b/README
@@ -1,9 +1,10 @@
 Uvccapture is a simple application for capturing images from an USB webcam on
 Linux. This repository contains my fork and hacks on uvccapture.
 
-My modificantions include:
+My modifications include:
 - Sequential numbering of files (img001.jpg, img002.jpg, ...).
 - Command line option for number of images to capture.
+- Command line option to skip initial frames prior to capturing
 - Allow capturing JPG format at any resolution supported by the camera. The
   original uvccapture switches to YUYV mode at resolution 960x720 and higher,
   while many cameras support MJPG at full resolution.

--- a/uvccapture.c
+++ b/uvccapture.c
@@ -60,6 +60,8 @@ void usage (void)
     fprintf (stderr,
              "-c<command>\tCommand to run after each image capture(executed as <command> <output_filename>)\n");
     fprintf (stderr,
+             "-j<integer>\tSkip <integer> frames before first capture\n");
+    fprintf (stderr,
              "-t<integer>\tTake continuous shots with <integer> seconds between them (0 for single shot)\n");
     fprintf (stderr,
              "-n<integer>\tTake <integer> shots then exit. Only applicable when delay is non-zero\n");
@@ -194,6 +196,7 @@ int main (int argc, char *argv[])
     int num = -1; /* number of images to capture */
     int verbose = 0;
     int delay = 0;
+    int skip = 0;
     int quality = 95;
     int post_capture_command_wait = 0;
     int multifile = 0;   /* flag indicating that we save to a multi-file sequence */
@@ -251,6 +254,10 @@ int main (int argc, char *argv[])
 
         case 'n':
             num = atoi (&argv[1][2]);
+            break;
+
+        case 'j':
+            skip = atoi (&argv[1][2]);
             break;
 
         case 't':
@@ -375,6 +382,8 @@ int main (int argc, char *argv[])
             free (videoIn);
             exit (1);
         }
+
+        if (skip > 0) { skip--; continue; }
 
         if ((difftime (time (NULL), ref_time) > delay) || delay == 0) {
             if (multifile == 1) {


### PR DESCRIPTION
This request adds a "-j<integer>" option to uvccapture to skip the first <integer> frames prior to capturing.  This is useful in some webcams (e.g., the Microsoft Lifecam series) where the camera needs a few frames to autofocus and autobalance before grabbing the desired picture.

I chose "-j" to match the similar option of guvcview(1).

Thanks!

Pm
